### PR TITLE
Add persistent cephfs storage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ test:
 	echo "Nothing to test!"
 
 helm:
-	helm template loki loki/loki -n app-loki > kubernetes/loki.yaml
+	helm template loki loki/loki -n app-loki -f config.yaml > kubernetes/loki.yaml
 
 
 .PHONY: cook-image push-image test helm

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,3 @@
+persistence:
+  enabled: True
+  storageClassName: cephfs

--- a/kubernetes/loki.yaml
+++ b/kubernetes/loki.yaml
@@ -233,5 +233,15 @@ spec:
         - name: config
           secret:
             secretName: loki
-        - name: storage
-          emptyDir: {}
+  volumeClaimTemplates:
+  - metadata:
+      name: storage
+      annotations:
+        {}
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: "10Gi"
+      storageClassName: cephfs


### PR DESCRIPTION
I'm not sure how to test this, but it looks like the pvc is being created.
```
❯ kubectl get events -n app-loki                           
LAST SEEN   TYPE      REASON                   OBJECT                                 MESSAGE
15m         Normal    Killing                  pod/loki-0                             Stopping container loki
10m         Warning   FailedScheduling         pod/loki-0                             pod has unbound immediate PersistentVolumeClaims (repeated 3 times)
10m         Normal    Scheduled                pod/loki-0                             Successfully assigned app-loki/loki-0 to riptide
10m         Normal    SuccessfulAttachVolume   pod/loki-0                             AttachVolume.Attach succeeded for volume "pvc-0c21ac4c-0c8a-4d15-b21a-1c18f48f1dce"
10m         Normal    Pulled                   pod/loki-0                             Container image "grafana/loki:v1.3.0" already present on machine
10m         Normal    Created                  pod/loki-0                             Created container loki
10m         Normal    Started                  pod/loki-0                             Started container loki
10m         Normal    SuccessfulCreate         statefulset/loki                       create Claim storage-loki-0 Pod loki-0 in StatefulSet loki success
10m         Normal    SuccessfulCreate         statefulset/loki                       create Pod loki-0 in StatefulSet loki successful
10m         Normal    ExternalProvisioning     persistentvolumeclaim/storage-loki-0   waiting for a volume to be created, either by external provisioner "cephfs.csi.ceph.com" or manually created by system administrator
10m         Normal    Provisioning             persistentvolumeclaim/storage-loki-0   External provisioner is provisioning volume for claim "app-loki/storage-loki-0"
10m         Normal    ProvisioningSucceeded    persistentvolumeclaim/storage-loki-0   Successfully provisioned volume pvc-0c21ac4c-0c8a-4d15-b21a-1c18f48f1dce
```